### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ encoding_rs = "0.8"
 futures-io = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "io"] }
 hreq-h1 = { version = "0.3.10" }
-h2 = { version = "0.3" }
+h2 = { version = "0.3.17" }
 http = "0.2"
 httparse = "1"
 httpdate = "0.3.2"


### PR DESCRIPTION
Updates dependency to the patch version of 0.3.17

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0034.html)